### PR TITLE
[Do Not Merge] Validate Debian workflow on QLI-AMI

### DIFF
--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -2,8 +2,8 @@ name: Daily Build
 
 on:
   # run daily at 8:30am
-  schedule:
-    - cron: '30 8 * * *'
+  #schedule:
+  #  - cron: '30 8 * * *'
   # allow manual runs
   workflow_dispatch:
 
@@ -17,7 +17,7 @@ permissions:
 jobs:
   build-daily:
     # don't run cron from forks of the main repository or from other branches
-    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    if: github.repository == 'qualcomm-linux-stg/qcom-deb-images' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/debos.yml
 
   test-daily:

--- a/.github/workflows/build-overlay-deb.yml
+++ b/.github/workflows/build-overlay-deb.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64, arm64]
-    runs-on: [self-hosted, qcom-u2404, "${{ matrix.arch }}"]
+    runs-on: [self-hosted, qcom-stg-u2404, "${{ matrix.arch }}"]
     container:
       image: public.ecr.aws/debian/debian:trixie
       options: --privileged  # Required for chroot creation
@@ -89,8 +89,8 @@ jobs:
           sudo -u builder python3 scripts/build-deb.py \
               --config "${{ inputs.config }}" --output-dir upload
 
-      - name: Upload as private artifacts
-        uses: qualcomm-linux/upload-private-artifact-action@v1
-        with:
-          path: upload
+      # - name: Upload as private artifacts
+      #   uses: qualcomm-linux/upload-private-artifact-action@v1
+      #   with:
+      #     path: upload
 

--- a/.github/workflows/debos.yml
+++ b/.github/workflows/debos.yml
@@ -37,7 +37,7 @@ jobs:
     name: Build and upload debos recipes
     outputs:
       url: ${{ steps.upload_artifacts.outputs.url }}
-    runs-on: [self-hosted, qcom-u2404, arm64]
+    runs-on: [self-hosted, qcom-stg-u2404, arm64]
     container:
       image: public.ecr.aws/debian/debian:trixie
       volumes:
@@ -144,11 +144,11 @@ jobs:
               disk-sdcard.img2 \
               flash_qrb2210-*
 
-      - name: Upload private artifacts
-        uses: qualcomm-linux/upload-private-artifact-action@v1
-        id: upload_artifacts
-        with:
-          path: debos-artifacts
+      # - name: Upload private artifacts
+      #   uses: qualcomm-linux/upload-private-artifact-action@v1
+      #   id: upload_artifacts
+      #   with:
+      #     path: debos-artifacts
 
       - name: Unpack rootfs to generate SBOM
         run: mkdir -v rootfs && tar -C rootfs -xf rootfs.tar.gz
@@ -193,11 +193,11 @@ jobs:
           mkdir -v sboms
           cp -av rootfs-sbom.*.gz sboms
 
-      - name: Upload SBOMs as private artifacts
-        uses: qualcomm-linux/upload-private-artifact-action@v1
-        id: upload_sbom_artifacts
-        with:
-          path: sboms
+      # - name: Upload SBOMs as private artifacts
+      #   uses: qualcomm-linux/upload-private-artifact-action@v1
+      #   id: upload_sbom_artifacts
+      #   with:
+      #     path: sboms
       - name: "Print output"
         env:
           build_url: ${{ steps.upload_artifacts.outputs.url }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,9 +2,9 @@ name: Build Linux kernel deb and debos image
 
 on:
   # run weekly on Monday at 8:30am
-  schedule:
-    - cron: '30 6 * * 1'
-  # allow manual runs
+  # schedule:
+  #   - cron: '30 6 * * 1'
+  # # allow manual runs
   workflow_dispatch:
 
 # implicitely set all other permissions to none
@@ -29,11 +29,11 @@ concurrency:
 jobs:
   build-linux-deb:
     # don't run cron from forks of the main repository or from other branches
-    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    #if: github.repository == 'qualcomm-linux-stg/qcom-deb-images' && github.ref == 'refs/heads/awsRunner'
     # for cross-builds
-    runs-on: [self-hosted, qcom-u2404, amd64]
+    runs-on: [self-hosted, qcom-stg-u2404, amd64]
     # alternative for native builds, but overkill to do both
-    #runs-on: [self-hosted, qcom-u2404, arm64]
+    #runs-on: [self-hosted, qcom-stg-u2404, arm64]
     container:
       image: public.ecr.aws/debian/debian:trixie
       volumes:
@@ -89,11 +89,11 @@ jobs:
           # perhaps help NFS sync
           sync
 
-      - name: Upload private artifacts
-        uses: qualcomm-linux/upload-private-artifact-action@v1
-        id: upload_artifacts
-        with:
-          path: artifacts
+      # - name: Upload private artifacts
+      #   uses: qualcomm-linux/upload-private-artifact-action@v1
+      #   id: upload_artifacts
+      #   with:
+      #     path: artifacts
 
   debos-mainline-linux:
     needs: build-linux-deb

--- a/.github/workflows/u-boot.yml
+++ b/.github/workflows/u-boot.yml
@@ -2,8 +2,8 @@ name: Build U-Boot for RB1
 
 on:
   # run weekly on Monday at 8:30am
-  schedule:
-    - cron: '30 6 * * 1'
+  # schedule:
+  #   - cron: '30 6 * * 1'
   # allow manual runs
   workflow_dispatch:
 
@@ -26,11 +26,11 @@ concurrency:
 jobs:
   build-u-boot-rb1:
     # don't run cron from forks of the main repository or from other branches
-    if: github.repository == 'qualcomm-linux/qcom-deb-images' && github.ref == 'refs/heads/main'
+    #if: github.repository == 'qualcomm-linux-stg/qcom-deb-images' && github.ref == 'refs/heads/main'
     # for cross-builds
-    runs-on: [self-hosted, qcom-u2404, amd64]
+    runs-on: [self-hosted, qcom-stg-u2404, amd64]
     # alternative for native builds, but overkill to do both
-    #runs-on: [self-hosted, qcom-u2404, arm64]
+    #runs-on: [self-hosted, qcom-stg-u2404, arm64]
     container:
       image: public.ecr.aws/debian/debian:trixie
       volumes:
@@ -90,9 +90,9 @@ jobs:
           # perhaps help NFS sync
           sync
 
-      - name: Upload private artifacts
-        uses: qualcomm-linux/upload-private-artifact-action@v1
-        id: upload_artifacts
-        with:
-          path: artifacts
+      # - name: Upload private artifacts
+      #   uses: qualcomm-linux/upload-private-artifact-action@v1
+      #   id: upload_artifacts
+      #   with:
+      #     path: artifacts
 


### PR DESCRIPTION
AWS runner will be setup with newly creted QLI-AMI and GH workflow needs validation for end to end testing, before we deploy this AMI in production.

For validation, I have disable the CRON runs and as well upload artifacts to GCP.